### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Stories in Ready](https://badge.waffle.io/WeCamp/island-of-the-dead.png?label=ready&title=Ready)](https://waffle.io/WeCamp/island-of-the-dead)
 # team-jasper


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/WeCamp/island-of-the-dead

This was requested by a real person (user StevendeVries) on waffle.io, we're not trying to spam you.
