### PR TITLE
Feature/surroundings fe add watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 ## FrontEnd Application (webapp) ##
 
-### Development mode ###
+### Development mode (local, prerequiste: install node.js) ###
 - Run `npm run dev` to start gulp which will build the project and start the watcher so changed files are being retranspiled to the build folder.
 - Run `npm run dev-server` to start nodemon and run server.js in development mode, so every change made to the sourcecode will result in a restart of the server.
 
-### Production mode ###
+### Production mode (vagrant box) ###
 - Run `npm run build` or `gulp` to start gulp, build the project and copy it to the build folder.
 - Run `npm start` to start server.js which will expose the contents of the build folder.
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 ## FrontEnd Application (webapp) ##
 
 ### Development mode ###
-Run `npm run dev` to start gulp which will build the project and start the watcher so changed files are being retranspiled to the build folder.
-Run `npm run dev-server` to start nodemon and run server.js in development mode, so every change made to the sourcecode will result in a restart of the server.
+- Run `npm run dev` to start gulp which will build the project and start the watcher so changed files are being retranspiled to the build folder.
+- Run `npm run dev-server` to start nodemon and run server.js in development mode, so every change made to the sourcecode will result in a restart of the server.
 
 ### Production mode ###
-Run `npm run build` to start gulp, build the project and copy it to the build folder.
-Run `npm start` to start server.js which will expose the contents of the build folder.
+- Run `npm run build` or `gulp` to start gulp, build the project and copy it to the build folder.
+- Run `npm start` to start server.js which will expose the contents of the build folder.
+
 
 ## BackEnd Application (api) ##
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@
 
 ### Development mode (local, prerequiste: install node.js) ###
 - Run `npm run dev` to start gulp which will build the project and start the watcher so changed files are being retranspiled to the build folder.
-- Run `npm run dev-server` to start nodemon and run server.js in development mode, so every change made to the sourcecode will result in a restart of the server.
+- Run `npm run dev-server` to start nodemon and run server.js in development mode, so every change made to the sourcecode will result in a restart of the server. Website is visible on http://localhost:7777
 
 ### Production mode (vagrant box) ###
 - Run `npm run build` or `gulp` to start gulp, build the project and copy it to the build folder.
-- Run `npm start` to start server.js which will expose the contents of the build folder.
-
+- Run `npm start` to start server.js which will expose the contents of the build folder. Website is now visible port 7777 with the ip address of your vagrant box.
 
 ## BackEnd Application (api) ##
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 [![Stories in Ready](https://badge.waffle.io/WeCamp/island-of-the-dead.png?label=ready&title=Ready)](https://waffle.io/WeCamp/island-of-the-dead)
 # team-jasper
 
+## FrontEnd Application (webapp) ##
+
+### Development mode ###
+Run `npm run dev` to start gulp which will build the project and start the watcher so changed files are being retranspiled to the build folder.
+Run `npm run dev-server` to start nodemon and run server.js in development mode, so every change made to the sourcecode will result in a restart of the server.
+
+### Production mode ###
+Run `npm run build` to start gulp, build the project and copy it to the build folder.
+Run `npm start` to start server.js which will expose the contents of the build folder.
+
+## BackEnd Application (api) ##
+
 Phpspec:
 To run the tests:
 phpspec run

--- a/webapp/app/App.jsx
+++ b/webapp/app/App.jsx
@@ -4,7 +4,7 @@ var App = React.createClass({
   render: function() {
     return (
       <div>
-        First React Item hooray
+        First React Item hooray yay yay
       </div>
     );
   }

--- a/webapp/gulpfile.js
+++ b/webapp/gulpfile.js
@@ -3,6 +3,12 @@ var browserify = require("browserify");
 var reactify = require("reactify");
 var source = require("vinyl-source-stream");
 
+const config = {
+  styles_src: "app/style.css",
+  html_src: "app/index.html",
+  destination_folder: "build",
+  jsx_src: ["*.js", "app/**/*.js", "app/**/*.jsx"]
+}
 gulp.task("bundle", function () {
     return browserify({
         entries: "./app/main.jsx",
@@ -14,10 +20,17 @@ gulp.task("bundle", function () {
 });
 
 gulp.task("copy", ["bundle"], function () {
-    return gulp.src(["app/index.html", "app/style.css"])
-        .pipe(gulp.dest("build"));
+    return gulp.src([config.html_src, config.styles_src])
+        .pipe(gulp.dest(config.destination_folder));
+});
+
+gulp.task("watch", function() {
+  gulp.watch(config.styles_src, ["copy"]);
+  gulp.watch(config.jsx_src, ["bundle"]);
 });
 
 gulp.task("default",["copy"],function(){
    console.log("Gulp completed...");
 });
+
+gulp.task("development", ["copy", "watch"])

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "gulp",
-    "dev" : "gulp development"
+    "dev": "gulp development",
+    "dev-server": "nodemon server.js"
   },
   "author": "",
   "license": "ISC",
@@ -15,6 +16,7 @@
     "browserify": "^13.1.0",
     "express": "^4.14.0",
     "gulp": "^3.9.1",
+    "nodemon": "^1.10.2",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "reactify": "^1.1.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,7 +5,9 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "gulp",
+    "dev" : "gulp development"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This feature adds a watcher on the gulpfiles and a a development mode for developing on your local machine.

From the readme:
### Development mode (local, prerequiste: install node.js)
- Run `npm run dev` to start gulp which will build the project and start the watcher so changed files are being retranspiled to the build folder.
- Run `npm run dev-server` to start nodemon and run server.js in development mode, so every change made to the sourcecode will result in a restart of the server. Website is visible on http://localhost:7777
### Production mode (vagrant box)
- Run `npm run build` or `gulp` to start gulp, build the project and copy it to the build folder.
- Run `npm start` to start server.js which will expose the contents of the build folder. Website is now visible port 7777 with the ip address of your vagrant box.
